### PR TITLE
add node 0.12, use containers in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+sudo: false
 script:
   - npm run lint
   - npm test


### PR DESCRIPTION
- ensuring tests against node `0.12.0`
- using containers in travis to make it faster! (`sudo: false`, [travis info](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/))