### PR TITLE
fixes for event fixes

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -374,22 +374,23 @@ var middlewares = module.exports = {
   getEvents: function () {
     return function (req, res) {
       // do streaming when params are not specified
-      // res.set('Content-Type', 'application/json');
-      res.writeHead(200, {
-        'content-Type': 'application/json',
-        'transfer-encoding': 'chunked'
-      });
-      // Force flush headers - Write headers to socket and mark as sent
-      res.socket.write(res._header);
-      res._headerSent = true;
       // send response immediately when params are there
       if (req.query.since || req.query.until) {
+        res.set('Content-Type', 'application/json');
         var data = '';
         for (var i = 0; i < 100; i++) {
           data += middlewares.generateEvent();
         }
+        console.log('sending');
         res.send(data);
       } else {
+        res.writeHead(200, {
+          'content-Type': 'application/json',
+          'transfer-encoding': 'chunked'
+        });
+        // Force flush headers - Write headers to socket and mark as sent
+        res.socket.write(res._header);
+        res._headerSent = true;
         middlewares.eventsStream.pipe(res);
         // by default every 100ms new random event would be generated
         // and pushed to the response stream


### PR DESCRIPTION
have to not send headers if just sending a chunk back, evidently