### PR TITLE
Handle name when creating a container and returning list of containers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,12 +48,6 @@ app.get('/containers/json', function (req, res, next) {
 app.post('/containers/create',
   bodyParser.json(),
   function (req, res, next) {
-    // Create api supports adding name as a query parameter
-    // https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-container
-    if (req.query.name) {
-      req.body.name = req.query.name
-    }
-
     containers
       .createContainer(req.body)
       .then(function (container) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,12 @@ app.get('/containers/json', function (req, res, next) {
 app.post('/containers/create',
   bodyParser.json(),
   function (req, res, next) {
+    // Create api supports adding name as a query parameter
+    // https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-container
+    if (req.query.name) {
+      req.body.name = req.query.name
+    }
+
     containers
       .createContainer(req.body)
       .then(function (container) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,12 @@ app.get('/containers/json', function (req, res, next) {
 app.post('/containers/create',
   bodyParser.json(),
   function (req, res, next) {
+    // Create api supports adding name as a query parameter
+    // https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#create-a-container
+    if (req.query.name) {
+      req.body.name = req.query.name
+    }
+
     containers
       .createContainer(req.body)
       .then(function (container) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,10 @@ var stream = require('stream')
 var tarStream = require('tar-stream')
 var ImageStore = require('./models/image-store')
 var ContainerStore = require('./models/container-store')
-var NotFoundError = require('./models/base-store').NotFoundError
-var NotModifiedError = require('./models/base-store').NotModifiedError
+var BaseStore = require('./models/base-store')
+var NotFoundError = BaseStore.NotFoundError
+var NotModifiedError = BaseStore.NotModifiedError
+var ConflictError = BaseStore.ConflictError
 
 var images = new ImageStore()
 var containers = new ContainerStore()
@@ -53,6 +55,7 @@ app.post('/containers/create',
       .then(function (container) {
         res.status(201).json(container)
       })
+      .catch(ConflictError, function (err) { res.status(err.statusCode).end(err.message) })
       .catch(next)
   })
 

--- a/lib/models/base-store.js
+++ b/lib/models/base-store.js
@@ -34,3 +34,12 @@ function NotModifiedError (message) {
   Error.call(this, message)
 }
 util.inherits(NotModifiedError, Error)
+
+module.exports.ConflictError = ConflictError
+
+function ConflictError (message) {
+  Error.call(this)
+  this.message = message
+  this.statusCode = 409
+}
+util.inherits(ConflictError, Error)

--- a/lib/models/container-store.js
+++ b/lib/models/container-store.js
@@ -63,10 +63,18 @@ ContainerStore.prototype.listContainers = function () {
       return Object.keys(this._store).map(function (storeId) {
         var container = this._store[storeId]
         // TODO: extend with other data we may want
+
+        // List containers api returns each container's name in a list named "Names"
+        // https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#list-containers
+        var Names
+        if (container.Name) {
+          Names = [container.Name]
+        }
         return {
           Id: container.Id,
           Image: container.Image,
-          Created: container.Created
+          Created: container.Created,
+          Names: Names
         }
       }.bind(this))
     })

--- a/lib/models/container-store.js
+++ b/lib/models/container-store.js
@@ -5,6 +5,7 @@ var find = require('101/find')
 var BaseStore = require('./base-store')
 var Container = require('./container')
 var Promise = require('bluebird')
+var ConflictError = BaseStore.ConflictError
 
 module.exports = ContainerStore
 
@@ -83,6 +84,18 @@ ContainerStore.prototype.listContainers = function () {
 ContainerStore.prototype.createContainer = function (body) {
   return Promise.resolve()
     .bind(this)
+    .then(function () {
+      if (body.name) {
+        return this.findOneByName(body.name)
+        .then(function (container) {
+          var errMsg = util.format('Conflict. The name "%s" is already in use by container %s.' +
+                       'You have to remove (or rename) that container to be able to reuse that name.',
+                       body.name, container.Id)
+          throw new ConflictError(errMsg)
+        }, function () { return true })
+      }
+      return Promise.resolve(true)
+    })
     .then(function () {
       var container = new Container(body)
       this._store[container.Id] = container

--- a/test/functional/containers.js
+++ b/test/functional/containers.js
@@ -62,6 +62,19 @@ describe('containers', function () {
       docker.getContainer(createData.name).remove(done)
     })
   })
+  it('should fail to create a named container if name is already in use', function (done) {
+    var createData = {
+      name: 'CoolContainer'
+    }
+    async.series([
+      docker.createContainer.bind(docker, createData),
+      docker.createContainer.bind(docker, createData)
+    ], function (err, results) {
+      assert.ok(results[0].id)
+      assert.equal(err.statusCode, 409)
+      docker.getContainer(results[0].id).remove(done)
+    })
+  })
   it('should list all the containers when there are none', function (done) {
     docker.listContainers(function (err, containers) {
       if (err) { return done(err) }

--- a/test/functional/containers.js
+++ b/test/functional/containers.js
@@ -41,15 +41,24 @@ describe('containers', function () {
     async.waterfall([
       docker.createContainer.bind(docker, createData),
       function (container, cb) {
-        container.inspect(cb)
+        async.parallel([
+          container.inspect.bind(container),
+          docker.listContainers.bind(docker)
+        ], function (err, results) {
+          cb(err, results)
+        })
       }
-    ], function (err, containerData) {
+    ], function (err, results) {
       if (err) { return done(err) }
+      var containerData = results[0]
+      var containers = results[1]
       // this should be capitalized and used
       assert.propertyVal(containerData, 'Name', '/' + createData.name)
       assert.isArray(containerData.Env)
       assert.lengthOf(containerData.Env, 1)
       assert.equal(containerData.Env[0], createData.Env[0])
+      assert.lengthOf(containers, 1)
+      assert.deepEqual(containers[0].Names, ['/hello'])
       docker.getContainer(createData.name).remove(done)
     })
   })

--- a/test/models/base-store.js
+++ b/test/models/base-store.js
@@ -27,6 +27,14 @@ describe('Base Store', function () {
     })
   })
 
+  describe('ConflictError', function () {
+    it('should expose ConflictError', function () {
+      assert.ok(BaseStore.ConflictError)
+      assert.doesNotThrow(function () { return new BaseStore.ConflictError() })
+      assert.ok(new BaseStore.ConflictError())
+    })
+  })
+
   describe('findOneById', function () {
     before(function () {
       store._store[4] = { hello: 'world' }

--- a/test/models/container-store.js
+++ b/test/models/container-store.js
@@ -8,6 +8,7 @@ var ContainerStore = require('../../lib/models/container-store')
 var createCount = require('callback-count')
 var EventEmitter = require('events').EventEmitter
 var NotFoundError = require('../../lib/models/base-store').NotFoundError
+var ConflictError = require('../../lib/models/base-store').ConflictError
 
 describe('Container Store', function () {
   var containers
@@ -86,6 +87,20 @@ describe('Container Store', function () {
         .then(function (containers) {
           assert.lengthOf(containers, 2)
         })
+    })
+    it('should create a container with a name', function () {
+      return assert.isFulfilled(containers.createContainer({name: 'new-container'}))
+        .then(function () {
+          return containers.listContainers()
+        })
+        .then(function (containers) {
+          assert.lengthOf(containers, 2)
+        })
+    })
+    it('should reject creating a container with an existing name with ConflictError', function () {
+      return assert.isRejected(
+        containers.createContainer({name: 'test-container'}), ConflictError
+      )
     })
     it('should register for container events and emit create', function (done) {
       var expectedEvents = [ 'create', 'start' ]


### PR DESCRIPTION
I just wanted to add functionality to get container's name from /containers/create api. 
I do not know why but Docker api returns each container's name in "Names" field when listing containers via /containers/json?all=1
(https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#list-containers)